### PR TITLE
Full project name (#37)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.1.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
+++ b/src/main/java/jenkins/plugins/logstash/persistence/BuildData.java
@@ -48,10 +48,8 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.WARNING;
-
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
@@ -105,11 +103,11 @@ public class BuildData {
       skipCount = testResultAction.getSkipCount();
       failCount = testResultAction.getFailCount();
       passCount = totalCount - skipCount - failCount;
- 
+
       failedTests = new ArrayList<String>();
       failedTestsWithErrorDetail = new ArrayList<FailedTest>();
       for (TestResult result : testResultAction.getFailedTests()) {
-    	  failedTests.add(result.getFullName());  
+          failedTests.add(result.getFullName());
           failedTestsWithErrorDetail.add(new FailedTest(result.getFullName(),result.getErrorDetails()));
       }
     }
@@ -118,6 +116,7 @@ public class BuildData {
   protected String id;
   protected String result;
   protected String projectName;
+  protected String fullProjectName;
   protected String displayName;
   protected String fullDisplayName;
   protected String description;
@@ -128,13 +127,12 @@ public class BuildData {
   protected long buildDuration;
   protected transient String timestamp; // This belongs in the root object
   protected String rootProjectName;
+  protected String rootFullProjectName;
   protected String rootProjectDisplayName;
   protected int rootBuildNum;
   protected Map<String, String> buildVariables;
   protected Set<String> sensitiveBuildVariables;
   protected TestData testResults = null;
-
-  BuildData() {}
 
   // Freestyle project build
   public BuildData(AbstractBuild<?, ?> build, Date currentTime, TaskListener listener) {
@@ -151,6 +149,7 @@ public class BuildData {
 
     // build.getDuration() is always 0 in Notifiers
     rootProjectName = build.getRootBuild().getProject().getName();
+    rootFullProjectName = build.getRootBuild().getProject().getFullName();
     rootProjectDisplayName = build.getRootBuild().getDisplayName();
     rootBuildNum = build.getRootBuild().getNumber();
     buildVariables = build.getBuildVariables();
@@ -195,6 +194,7 @@ public class BuildData {
     }
 
     rootProjectName = projectName;
+    rootFullProjectName = fullProjectName;
     rootProjectDisplayName = displayName;
     rootBuildNum = buildNum;
 
@@ -211,6 +211,7 @@ public class BuildData {
     result = build.getResult() == null ? null : build.getResult().toString();
     id = build.getId();
     projectName = build.getParent().getName();
+    fullProjectName = build.getParent().getFullName();
     displayName = build.getDisplayName();
     fullDisplayName = build.getFullDisplayName();
     description = build.getDescription();
@@ -259,6 +260,14 @@ public class BuildData {
 
   public void setProjectName(String projectName) {
     this.projectName = projectName;
+  }
+
+  public String getFullProjectName() {
+    return fullProjectName;
+  }
+
+  public void setFullProjectName(String fullProjectName) {
+    this.fullProjectName = fullProjectName;
   }
 
   public String getDisplayName() {
@@ -339,6 +348,14 @@ public class BuildData {
 
   public void setRootProjectName(String rootProjectName) {
     this.rootProjectName = rootProjectName;
+  }
+
+  public String getRootFullProjectName() {
+    return rootFullProjectName;
+  }
+
+  public void setRootFullProjectName(String rootFullProjectName) {
+    this.rootFullProjectName = rootFullProjectName;
   }
 
   public String getRootProjectDisplayName() {

--- a/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashNotifierTest.java
@@ -87,7 +87,6 @@ public class LogstashNotifierTest {
     errorBuffer = new ByteArrayOutputStream();
     errorStream = new PrintStream(errorBuffer, true);
 
-    when(mockBuild.getLog(anyInt())).thenReturn(Arrays.asList("line 1", "line 2", "line 3"));
     mockRun = new MockRun(mock(AbstractProject.class));
 
     when(mockListener.getLogger()).thenReturn(errorStream);

--- a/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
+++ b/src/test/java/jenkins/plugins/logstash/LogstashWriterTest.java
@@ -84,9 +84,9 @@ public class LogstashWriterTest {
     when(mockBuild.getResult()).thenReturn(Result.SUCCESS);
     when(mockBuild.getDisplayName()).thenReturn("LogstashNotifierTest");
     when(mockBuild.getProject()).thenReturn(mockProject);
+    when(mockBuild.getParent()).thenReturn(mockProject);
     when(mockBuild.getBuiltOn()).thenReturn(null);
     when(mockBuild.getNumber()).thenReturn(123456);
-    when(mockBuild.getDuration()).thenReturn(0L);
     when(mockBuild.getTimestamp()).thenReturn(new GregorianCalendar());
     when(mockBuild.getRootBuild()).thenReturn(mockBuild);
     when(mockBuild.getBuildVariables()).thenReturn(Collections.emptyMap());
@@ -104,6 +104,7 @@ public class LogstashWriterTest {
     when(mockTestResultAction.getFailedTests()).thenReturn(Collections.emptyList());
 
     when(mockProject.getName()).thenReturn("LogstashWriterTest");
+    when(mockProject.getFullName()).thenReturn("parent/LogstashWriterTest");
 
     when(mockDao.buildPayload(Matchers.any(BuildData.class), Matchers.anyString(), Matchers.anyListOf(String.class)))
       .thenReturn(JSONObject.fromObject("{\"data\":{},\"message\":[\"test\"],\"source\":\"jenkins\",\"source_host\":\"http://my-jenkins-url\",\"@version\":1}"));
@@ -134,6 +135,8 @@ public class LogstashWriterTest {
     verify(mockBuild).getId();
     verify(mockBuild, times(2)).getResult();
     verify(mockBuild, times(2)).getParent();
+    verify(mockBuild, times(2)).getProject();
+    verify(mockBuild, times(1)).getStartTimeInMillis();
     verify(mockBuild, times(2)).getDisplayName();
     verify(mockBuild).getFullDisplayName();
     verify(mockBuild).getDescription();
@@ -142,7 +145,7 @@ public class LogstashWriterTest {
     verify(mockBuild).getBuiltOn();
     verify(mockBuild, times(2)).getNumber();
     verify(mockBuild).getTimestamp();
-    verify(mockBuild, times(3)).getRootBuild();
+    verify(mockBuild, times(4)).getRootBuild();
     verify(mockBuild).getBuildVariables();
     verify(mockBuild).getSensitiveBuildVariables();
     verify(mockBuild).getEnvironments();
@@ -154,6 +157,7 @@ public class LogstashWriterTest {
     verify(mockTestResultAction, times(1)).getFailedTests();
 
     verify(mockProject, times(2)).getName();
+    verify(mockProject, times(2)).getFullName();
 
     // Verify results
     assertEquals("Results don't match", "", errorBuffer.toString());

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
* add fullProjectName to BuildData
* with folders the projectName alone is not unique, so we should also expose the fullProjectName
* use mockito 2.1.0 to be able to mock final methods
* include full names in test
* have BuildData generate the json from mocks and not from the setters; this way we verify the fullProjectName and others are properly retrieved.